### PR TITLE
Added Meeting Minutes Template

### DIFF
--- a/.github/meeting_minutes_template.md
+++ b/.github/meeting_minutes_template.md
@@ -1,0 +1,24 @@
+# Meeting Minutes for [Day] - [Date]
+### Starting Time
+<!--- Place start time here --->
+
+### Ending Time
+<!--- Place end time here --->
+
+### Attendees
+<!--- List of attendees --->
+
+<!--- Optional: Apologies from people unable to attend --->
+
+## Topics of Discussion
+<!--- All topics raised for discussion go here --->
+
+<!--- Do this for as many topics as are brought up
+####  Topic
+ - [ ] Resolved?
+
+Discussion of topic...
+
+List of all items required to resolve this discussion
+
+--->


### PR DESCRIPTION
GitHub Issue (If applicable): #37 

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?
Currently we do not have a template for meeting minutes for the wiki. As the Issue addresses, this makes it difficult to keep meeting minutes to a standard that is easily readable and extendable.

## What is the new behavior?
I've added a new meeting minutes template in the .github folder which, if we continue to use it, should help with readability and maintainability.

Unfortunately, I'm not aware of any way to make this enforced or automatic. So, for now, I think this will need to be manually copied over everytime we wish to make some new meeting minutes (which shouldn't be too difficult as we only meet once a week currently).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [x] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 

## Other information
I think we should look further into possibly making this automatic. My initial research didn't find anything promising.

I'd also think we should possibly update this in future if we do not find it satisfactory, or if we think it needs to be changed to accommodate for something I haven't anticipated.

Internal Issue (If applicable):
#37
