### PR TITLE
Feature/chest inventory

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -37,8 +37,8 @@ export const MAP_PADDING_DISTANCE = 5;
 export const MAP_TRANSITION_DELAY = 500;
 
 // Create the chest's name given it's (x, y) coordinates.
-export function chestName(x, y) {
-    return x + ',' + y;
+export function chestName(map, x, y) {
+    return map + '(' + x + ',' + y + ')';
 }
 
 // Retrieve a coordinate (x, y) from a position.

--- a/src/features/player/actions/explore-chest.js
+++ b/src/features/player/actions/explore-chest.js
@@ -6,7 +6,8 @@ export default function exploreChest(x, y) {
         const { world } = getState();
         const { chests } = world;
 
-        const chest = chests[chestName(x, y)];
+        const { currentMap } = world;
+        const chest = chests[chestName(currentMap, x, y)];
         if (chest !== undefined) {
             dispatch({
                 type: 'SET_CHEST_DATA',

--- a/src/features/world/reducer.js
+++ b/src/features/world/reducer.js
@@ -49,7 +49,9 @@ const worldReducer = (state = initialState, { type, payload }) => {
                     currentMapData.tiles[y][x].value = -2;
                 } else if (x !== undefined && y !== undefined) {
                     // We still have an item in this chest, so let's ensure it stays there.
-                    newState.chests[chestName(x, y)] = { item: item };
+                    newState.chests[chestName(state.currentMap, x, y)] = {
+                        item: item,
+                    };
                 }
             }
 
@@ -60,7 +62,9 @@ const worldReducer = (state = initialState, { type, payload }) => {
             const chest = state.chests[chestName(x, y)];
             if (chest === undefined) {
                 // This chest hasn't been opened before, so let's generate one
-                state.chests[chestName(x, y)] = { item: null };
+                state.chests[chestName(state.currentMap, x, y)] = {
+                    item: null,
+                };
             }
 
             newState = _cloneDeep(state);

--- a/src/features/world/reducer.js
+++ b/src/features/world/reducer.js
@@ -47,8 +47,13 @@ const worldReducer = (state = initialState, { type, payload }) => {
                     // This chest has either been completely looted, or there never was an item in it.
                     // This will make the chest appear to the player as open.
                     currentMapData.tiles[y][x].value = -2;
-                } else if (x !== undefined && y !== undefined) {
-                    // We still have an item in this chest, so let's ensure it stays there.
+                }
+
+                if (x !== undefined && y !== undefined) {
+                    // This will either:
+                    //   1. Ensure any item's left in the chest are still there, or
+                    //   2. Ensure that the item for this chest is null (meaning it
+                    //      either never had an item, or it was just looted completely)
                     newState.chests[chestName(state.currentMap, x, y)] = {
                         item: item,
                     };


### PR DESCRIPTION
GitHub Issue (If applicable): #58 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Some chest's will open as if they were already looted, and the player won't get anything from them (other than an item, if a certain other chest also had an item).

## What is the new behavior?
So, because of how it was done with the previous storing of items, some
chests would start off 'looted' simply because they mapped to the same
key in the object for it.

Now, the chest's will create a key using the position as well as the map
name, which should make theoretically unique chests (assuming we can't
have multiple chests in the same spot on the same map).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 

Internal Issue (If applicable): closes #58
