### PR TITLE
Fix Missing Chest Dialog on Level Up

### DIFF
--- a/src/features/dialog-manager/actions/close-chest-dialog.js
+++ b/src/features/dialog-manager/actions/close-chest-dialog.js
@@ -1,24 +1,5 @@
-import { spriteToCoordinates } from '../../../config/constants';
-
 export default function closeChestDialog() {
-    return (dispatch, getState) => {
-        const { dialog, player } = getState();
-        const { chestOpen } = dialog;
-        const { position } = player;
-
-        const { x, y } = spriteToCoordinates(position);
-
-        // Ensure that if any items are left in the chest, that stays in the chest
-        dispatch({
-            type: 'SET_CHEST_DATA',
-            payload: {
-                gold: 0,
-                exp: 0,
-                item: chestOpen.item,
-                x: x,
-                y: y,
-            },
-        });
+    return dispatch => {
         dispatch({
             type: 'PAUSE',
             payload: { pause: false },

--- a/src/features/dialog-manager/actions/open-chest.js
+++ b/src/features/dialog-manager/actions/open-chest.js
@@ -18,7 +18,7 @@ export default function openChest() {
         ) {
             // Give the player a 25% chance to get a random item, only if there isn't an item already in it
             const chance = Math.floor(Math.random() * 100) + 1;
-            if (chance <= 250) {
+            if (chance <= 25) {
                 itemDrop = randomItem(level);
             }
         } else {

--- a/src/features/dialog-manager/actions/open-chest.js
+++ b/src/features/dialog-manager/actions/open-chest.js
@@ -4,13 +4,12 @@ import { spriteToCoordinates } from '../../../config/constants';
 export default function openChest() {
     return (dispatch, getState) => {
         const { stats, dialog, player } = getState();
-        const { level, expToLevel } = stats;
+        const { level } = stats;
 
         const { chestOpen } = dialog;
         const { item } = chestOpen;
-        const { position } = player;
 
-        let { x, y } = spriteToCoordinates(position);
+        const { x, y } = spriteToCoordinates(player.position);
 
         let itemDrop = null;
         if (
@@ -19,7 +18,7 @@ export default function openChest() {
         ) {
             // Give the player a 25% chance to get a random item, only if there isn't an item already in it
             const chance = Math.floor(Math.random() * 100) + 1;
-            if (chance <= 25) {
+            if (chance <= 250) {
                 itemDrop = randomItem(level);
             }
         } else {
@@ -33,14 +32,6 @@ export default function openChest() {
         const exp = level * 5 + 5;
 
         dispatch({
-            type: 'GET_GOLD',
-            payload: gold,
-        });
-        dispatch({
-            type: 'GET_EXP',
-            payload: exp,
-        });
-        dispatch({
             type: 'SET_CHEST_DATA',
             payload: {
                 exp,
@@ -50,15 +41,5 @@ export default function openChest() {
                 y: y,
             },
         });
-        if (exp + stats.exp >= expToLevel) {
-            dispatch({
-                type: 'PAUSE',
-                payload: {
-                    pause: true,
-                    levelUp: true,
-                    chest: true,
-                },
-            });
-        }
     };
 }

--- a/src/features/dialog-manager/dialogs/chest-loot/index.js
+++ b/src/features/dialog-manager/dialogs/chest-loot/index.js
@@ -18,8 +18,11 @@ const ChestLoot = ({ dialog, pickupItem, openChest, closeChestDialog }) => {
     }, []);
 
     function handleContinue() {
-        pickupItem();
+        // Do it this way so this dialog is closed first
         closeChestDialog();
+        // ... before we actually give them their items, which allows
+        //     the level up dialog to occur after this dialog.
+        pickupItem();
     }
 
     return (

--- a/src/features/inventory/actions/pickup-item.js
+++ b/src/features/inventory/actions/pickup-item.js
@@ -2,17 +2,38 @@ import { spriteToCoordinates } from '../../../config/constants';
 
 export default function pickupItem() {
     return (dispatch, getState) => {
-        const { inventory, dialog, player } = getState();
+        const { inventory, dialog, player, stats } = getState();
 
-        const { item } = dialog.chestOpen;
+        const { gold, exp, item } = dialog.chestOpen;
+
+        if (gold > 0) {
+            dispatch({
+                type: 'GET_GOLD',
+                payload: gold,
+            });
+        }
+
+        if (exp > 0) {
+            dispatch({
+                type: 'GET_EXP',
+                payload: exp,
+            });
+
+            if (exp + stats.exp >= stats.expToLevel) {
+                dispatch({
+                    type: 'PAUSE',
+                    payload: {
+                        pause: true,
+                        levelUp: true,
+                    },
+                });
+            }
+        }
 
         if (!item) return;
 
-        const { position } = player;
-
         const { items, maxItems } = inventory;
-
-        const { x, y } = spriteToCoordinates(position);
+        const { x, y } = spriteToCoordinates(player.position);
 
         if (items.length < maxItems) {
             // The item has now been taken, so make sure it gets deleted


### PR DESCRIPTION
GitHub Issue (If applicable): #60 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
If you level up from looting a chest, you wouldn't be able to see the contents of the chest.


## What is the new behavior?
After the player opens a chest, if they leveled up during the process, they will then receive the level up dialog.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 

Internal Issue (If applicable): closes #60 
