### PR TITLE
Align stats box for smalls screens

### DIFF
--- a/src/features/game-menus/index.js
+++ b/src/features/game-menus/index.js
@@ -27,6 +27,7 @@ const GameMenus = ({ appState, dialog }) => {
                 style={{
                     maxWidth: largeView ? 400 : 350,
                     paddingLeft: sideMenu ? 8 : 0,
+                    top: sideMenu ? -11 : 0,
                     height: sideMenu ? '380px' : 'unset',
                     justifyContent: disableInventory ? 'flex-end' : 'center',
                 }}

--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -90,7 +90,7 @@ class Snackbar extends Component {
                 className="snackbar__container white-border"
                 style={{
                     marginLeft: sideMenu ? -402 : 0,
-                    top: sideMenu ? 340 : -50,
+                    top: sideMenu ? 350 : -50,
                     width,
                     height: sideMenu ? 50 : 40,
                     fontSize: sideMenu ? 18 : 20,


### PR DESCRIPTION
GitHub Issue (If applicable): #65 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Stat box is not aligned with the game box for small screens.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Stat box is aligned with the game box for small screens.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
Closes #65 