### PR TITLE
Fix Empty Chests on Third Open

### DIFF
--- a/src/features/world/reducer.js
+++ b/src/features/world/reducer.js
@@ -64,7 +64,7 @@ const worldReducer = (state = initialState, { type, payload }) => {
 
         case 'OPEN_CHEST':
             const { x, y } = payload;
-            const chest = state.chests[chestName(x, y)];
+            const chest = state.chests[chestName(state.currentMap, x, y)];
             if (chest === undefined) {
                 // This chest hasn't been opened before, so let's generate one
                 state.chests[chestName(state.currentMap, x, y)] = {


### PR DESCRIPTION
GitHub Issue (If applicable): #68 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
If the player closed a chest a second time, and then went to open it any previous items would have disappeared.

## What is the new behavior?
Hopefully the player can now open the chest any number of times (while it still has items in it), and still see the item.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): closes #68 
