### PR TITLE
Add constant for ability points fixes #88

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -39,3 +39,5 @@ export const MAP_TRANSITION_DELAY = 500;
 export const MAX_ABILITY_SCORE = 20;
 // The default value of an ability score
 export const STARTING_ABILITY_SCORE_VALUE = 8;
+// The starting points a player can allocate
+export const STARTING_ABILITY_POINTS = 40;


### PR DESCRIPTION
The constant was mistakenly deleted in 334ef8c and this adds it back.

GitHub Issue (If applicable): #88 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

The constant `STARTING_ABILITY_POINTS` is not defined.


## What is the new behavior?

The constant `STARTING_ABILITY_POINTS` is defined.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): closes #88 
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
