### PR TITLE
Add Ability Dialog on Level Up

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -41,3 +41,5 @@ export const MAX_ABILITY_SCORE = 20;
 export const STARTING_ABILITY_SCORE_VALUE = 8;
 // The starting points a player can allocate
 export const STARTING_ABILITY_POINTS = 40;
+// The number of ability points the player gets to allocate on levelling up
+export const LEVEL_UP_ABILITY_POINTS = 2;

--- a/src/features/dialog-manager/actions/ability-score-dialog.js
+++ b/src/features/dialog-manager/actions/ability-score-dialog.js
@@ -1,0 +1,24 @@
+import { LEVEL_UP_ABILITY_POINTS } from '../../../config/constants';
+
+export default function abilityScoreDialog() {
+    return (dispatch, getState) => {
+        const { abilities } = getState().stats;
+        abilities.points = LEVEL_UP_ABILITY_POINTS;
+
+        dispatch({
+            type: 'LEVEL_UP_ABILITIES',
+            payload: {
+                abilities: abilities,
+            },
+        });
+
+        dispatch({
+            type: 'PAUSE',
+            payload: {
+                pause: true,
+                abilityDialog: true,
+                fromLevelUp: true,
+            },
+        });
+    };
+}

--- a/src/features/dialog-manager/actions/confirm-ability-score-dialog.js
+++ b/src/features/dialog-manager/actions/confirm-ability-score-dialog.js
@@ -8,6 +8,7 @@ export default function confirmAbilityScoreDialog() {
             wisdom,
             intelligence,
         } = getState().dialog.abilities;
+
         dispatch({
             type: 'SET_ABILITY_SCORES',
             payload: {
@@ -22,12 +23,22 @@ export default function confirmAbilityScoreDialog() {
             },
         });
 
-        dispatch({
-            type: 'PAUSE',
-            payload: {
-                pause: true,
-                gameInstructions: true,
-            },
-        });
+        if (getState().dialog.fromLevelUp) {
+            dispatch({
+                type: 'PAUSE',
+                payload: {
+                    pause: false,
+                    fromLevelUp: false,
+                },
+            });
+        } else {
+            dispatch({
+                type: 'PAUSE',
+                payload: {
+                    pause: true,
+                    gameInstructions: true,
+                },
+            });
+        }
     };
 }

--- a/src/features/dialog-manager/dialogs/ability-dialog/index.js
+++ b/src/features/dialog-manager/dialogs/ability-dialog/index.js
@@ -48,13 +48,9 @@ const AbilityDialog = ({
         points,
     } = dialog.abilities;
 
-    const finishAllocation = () => {
-        confirmAbilityScoreDialog();
-    };
-
     return (
         <>
-            <Dialog onKeyPress={finishAllocation}>
+            <Dialog onKeyPress={confirmAbilityScoreDialog}>
                 <div className="flex-column ability-score-dialog__container">
                     <span className="game-text-dialog__text">
                         Modify your Abilities
@@ -103,7 +99,7 @@ const AbilityDialog = ({
                     </span>
                     <Button
                         title="Confirm"
-                        onClick={finishAllocation}
+                        onClick={confirmAbilityScoreDialog}
                         small={true}
                     />
                 </div>

--- a/src/features/dialog-manager/dialogs/level-up/index.js
+++ b/src/features/dialog-manager/dialogs/level-up/index.js
@@ -4,18 +4,22 @@ import { connect } from 'react-redux';
 import Button from '../../../../components/button';
 import MicroDialog from '../../../../components/micro-dialog';
 import closeLevelUpDialog from '../../actions/close-level-up-dialog';
+import abilityScoreDialog from '../../actions/ability-score-dialog';
+
+import isAbilityAllocationLevel from '../../../../utils/is-ability-allocation-level';
 
 import './styles.scss';
 
-const LevelUp = ({ stats, closeLevelUpDialog }) => {
+const LevelUp = ({ stats, closeLevelUpDialog, abilityScoreDialog }) => {
     const { level, levelUp } = stats;
     const { dmg, hp } = levelUp;
 
+    const nextDialog = isAbilityAllocationLevel(level)
+        ? abilityScoreDialog
+        : closeLevelUpDialog;
+
     return (
-        <MicroDialog
-            onClose={closeLevelUpDialog}
-            onKeyPress={closeLevelUpDialog}
-        >
+        <MicroDialog onClose={nextDialog} onKeyPress={nextDialog}>
             <span className="level-up__title">
                 Level<span className="level-up__level">{` ${level}`}</span>
             </span>
@@ -32,11 +36,7 @@ const LevelUp = ({ stats, closeLevelUpDialog }) => {
             </div>
 
             <div className="flex-column level-up__buttons">
-                <Button
-                    onClick={closeLevelUpDialog}
-                    title={'Okay'}
-                    icon={'check'}
-                />
+                <Button onClick={nextDialog} title={'Okay'} icon={'check'} />
             </div>
         </MicroDialog>
     );
@@ -44,6 +44,6 @@ const LevelUp = ({ stats, closeLevelUpDialog }) => {
 
 const mapStateToProps = ({ stats }) => ({ stats });
 
-const actions = { closeLevelUpDialog };
+const actions = { closeLevelUpDialog, abilityScoreDialog };
 
 export default connect(mapStateToProps, actions)(LevelUp);

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -18,6 +18,7 @@ const initialState = {
     settings: false,
     inventory: false,
     levelUp: false,
+    fromLevelUp: false,
     abilityDialog: false,
     abilities: {
         constitution: STARTING_ABILITY_SCORE_VALUE,
@@ -28,10 +29,18 @@ const initialState = {
         charisma: STARTING_ABILITY_SCORE_VALUE,
         points: STARTING_ABILITY_POINTS,
     },
+    abilities_minimum: {
+        min_constitution: 0,
+        min_dexterity: 0,
+        min_strength: 0,
+        min_wisdom: 0,
+        min_intelligence: 0,
+        min_charisma: 0,
+    },
 };
 
 const dialogManagerReducer = (state = initialState, { type, payload }) => {
-    const { abilities } = state;
+    const { abilities, abilities_minimum } = state;
     const {
         constitution,
         intelligence,
@@ -41,6 +50,15 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
         charisma,
         points,
     } = abilities;
+
+    const {
+        min_constitution,
+        min_intelligence,
+        min_strength,
+        min_dexterity,
+        min_wisdom,
+        min_charisma,
+    } = abilities_minimum;
 
     switch (type) {
         case 'PAUSE':
@@ -55,6 +73,7 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
                 gameSelect,
                 gameInstructions,
                 levelUp,
+                fromLevelUp,
                 abilityDialog,
                 pause,
             } = payload;
@@ -62,6 +81,7 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
             return {
                 ...state,
                 levelUp: levelUp || false,
+                fromLevelUp: fromLevelUp || false,
                 shop: shop || false,
                 chest: chest || false,
                 gameStart: gameStart || false,
@@ -113,6 +133,20 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
 
             return state;
 
+        case 'LEVEL_UP_ABILITIES':
+            return {
+                ...state,
+                abilities: payload.abilities,
+                abilities_minimum: {
+                    min_charisma: payload.abilities.charisma,
+                    min_constitution: payload.abilities.constitution,
+                    min_strength: payload.abilities.strength,
+                    min_intelligence: payload.abilities.intelligence,
+                    min_wisdom: payload.abilities.wisdom,
+                    min_dexterity: payload.abilities.dexterity,
+                },
+            };
+
         case 'INCREMENT_CHARISMA':
             if (points < 1 || charisma >= MAX_ABILITY_SCORE) {
                 return { ...state };
@@ -126,7 +160,7 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
                 },
             };
         case 'DECREMENT_CHARISMA':
-            if (charisma < 1) {
+            if (charisma <= min_charisma) {
                 return { ...state };
             }
             return {
@@ -151,7 +185,7 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
             };
 
         case 'DECREMENT_CONSTITUTION':
-            if (constitution < 1) {
+            if (constitution <= min_constitution) {
                 return { ...state };
             }
             return {
@@ -176,7 +210,7 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
                 },
             };
         case 'DECREMENT_STRENGTH':
-            if (strength < 1) {
+            if (strength <= min_strength) {
                 return { ...state };
             }
             return {
@@ -201,7 +235,7 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
                 },
             };
         case 'DECREMENT_WISDOM':
-            if (wisdom < 1) {
+            if (wisdom <= min_wisdom) {
                 return { ...state };
             }
             return {
@@ -226,7 +260,7 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
                 },
             };
         case 'DECREMENT_DEXTERITY':
-            if (dexterity < 1) {
+            if (dexterity <= min_dexterity) {
                 return { ...state };
             }
             return {
@@ -251,7 +285,7 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
                 },
             };
         case 'DECREMENT_INTELLIGENCE':
-            if (intelligence < 1) {
+            if (intelligence <= min_intelligence) {
                 return { ...state };
             }
             return {

--- a/src/utils/is-ability-allocation-level.js
+++ b/src/utils/is-ability-allocation-level.js
@@ -1,0 +1,4 @@
+// Check if the level the player is at provides them with more ability points.
+export default function isAbilityAllocationLevel(level) {
+    return level % 5 === 1;
+}

--- a/src/utils/is-ability-allocation-level.js
+++ b/src/utils/is-ability-allocation-level.js
@@ -1,4 +1,4 @@
 // Check if the level the player is at provides them with more ability points.
 export default function isAbilityAllocationLevel(level) {
-    return level % 5 === 1;
+    return level % 5 === 0;
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #90 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
The player is only able to allocate points at the start of the game, and will receive no further points as they level up.

## What is the new behavior?
The player, after every 5 levels, is allocated 2 more points that they can allocate as they so wish in the form of an ability dialog that appears after they level up. The player is unable to lower an ability below what they currently have (so, if they currently have 15 strength, they will leave the dialog with strength >= 15).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 

Internal Issue (If applicable): closes #90