### PR TITLE
Using a potion displays 'used item' closes #85

### DIFF
--- a/src/features/inventory/actions/consume-potion.js
+++ b/src/features/inventory/actions/consume-potion.js
@@ -6,7 +6,7 @@ export default function consumePotion(item) {
         });
 
         dispatch({
-            type: 'DROP_ITEM',
+            type: 'USE_ITEM',
             payload: item,
         });
     };

--- a/src/features/inventory/reducer.js
+++ b/src/features/inventory/reducer.js
@@ -13,6 +13,7 @@ const inventoryReducer = (state = initialState, { type, payload }) => {
 
     switch (type) {
         case 'DROP_ITEM':
+        case 'USE_ITEM':
             newState = _cloneDeep(state);
 
             newState.items.find((itemData, index) => {

--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -22,17 +22,31 @@ class Snackbar extends Component {
     componentDidUpdate(prevProps, prevState) {
         const {
             itemReceived,
+            itemUsed,
             itemDropped,
             notEnoughGold,
             tooManyItems,
             item,
         } = this.props.snackbar;
+
         const lastItemReceived = prevProps.snackbar.itemReceived;
         const lastItemDropped = prevProps.snackbar.itemDropped;
+        const lastItemUsed = prevProps.snackbar.itemUsed;
         const lastNotEnoughGold = prevProps.snackbar.notEnoughGold;
         const lastTooManyItems = prevProps.snackbar.tooManyItems;
 
         if (
+            lastItemUsed !== itemUsed &&
+            itemUsed &&
+            typeof itemUsed !== 'undefined'
+        ) {
+            // see if any items were used
+            this.setState({
+                show: `USED AN ITEM: ${itemUsed.split('-')[0]}`,
+                item: item,
+            });
+            this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
+        } else if (
             lastItemDropped !== itemDropped &&
             itemDropped &&
             typeof itemDropped !== 'undefined'

--- a/src/features/snackbar/reducer.js
+++ b/src/features/snackbar/reducer.js
@@ -2,6 +2,7 @@ const initialState = {
     notEnoughGold: '',
     tooManyItems: '',
     itemDropped: '',
+    itemUsed: '',
     itemReceived: '',
     item: null,
 };

--- a/src/features/snackbar/reducer.js
+++ b/src/features/snackbar/reducer.js
@@ -36,6 +36,13 @@ const snackbarReducer = (state = initialState, { type, payload }) => {
                 item: payload,
             };
 
+        case 'USE_ITEM':
+            return {
+                ...state,
+                itemUsed: `${payload.name}-${new Date().getTime()}`,
+                item: payload,
+            };
+
         case 'RESET':
             return initialState;
 


### PR DESCRIPTION
GitHub Issue (If applicable): #85 

## PR Type

What kind of change does this PR introduce?
- Feature
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Displays 'Lost an item: HP potion' when using a health potion to restore health.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Displays 'Used an item: HP potion' when using a health potion to restore health.
<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [x] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->

Internal Issue (If applicable):
closes #85 
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
