### PR TITLE
Change snackbar notifications closes #83

### DIFF
--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -80,7 +80,7 @@ class Snackbar extends Component {
         ) {
             // see if player tried to get item with full inventory
             this.setState({
-                show: `NOT ENOUGH SPACE FOR: ${tooManyItems.split('-')[0]}`,
+                show: `NO ROOM FOR: ${tooManyItems.split('-')[0]}`,
                 item: item,
             });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);

--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -42,7 +42,7 @@ class Snackbar extends Component {
         ) {
             // see if any items were used
             this.setState({
-                show: `USED AN ITEM: ${itemUsed.split('-')[0]}`,
+                show: `USED ITEM: ${itemUsed.split('-')[0]}`,
                 item: item,
             });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
@@ -51,19 +51,11 @@ class Snackbar extends Component {
             itemDropped &&
             typeof itemDropped !== 'undefined'
         ) {
-            // see if potion was dropped (i.e. used)
-            if (item.type === 'potion') {
-                this.setState({
-                    show: `USED ITEM: ${itemDropped.split('-')[0]}`,
-                    item: item,
-                });
-            } else {
-                // see if any items were dropped
-                this.setState({
-                    show: `LOST ITEM: ${itemDropped.split('-')[0]}`,
-                    item: item,
-                });
-            }
+            // see if any items were dropped
+            this.setState({
+                show: `LOST ITEM: ${itemDropped.split('-')[0]}`,
+                item: item,
+            });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
         } else if (
             lastItemReceived !== itemReceived &&
@@ -83,7 +75,7 @@ class Snackbar extends Component {
         ) {
             // see if player tried to buy item without enough gold
             this.setState({
-                show: `NOT ENOUGH GOLD FOR: ${notEnoughGold.split('-')[0]}`,
+                show: `NO GOLD FOR: ${notEnoughGold.split('-')[0]}`,
                 item: item,
             });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);

--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -37,11 +37,19 @@ class Snackbar extends Component {
             itemDropped &&
             typeof itemDropped !== 'undefined'
         ) {
-            // see if any items were dropped
-            this.setState({
-                show: `LOST AN ITEM: ${itemDropped.split('-')[0]}`,
-                item: item,
-            });
+            // see if potion was dropped (i.e. used)
+            if (item.type === 'potion') {
+                this.setState({
+                    show: `USED ITEM: ${itemDropped.split('-')[0]}`,
+                    item: item,
+                });
+            } else {
+                // see if any items were dropped
+                this.setState({
+                    show: `LOST ITEM: ${itemDropped.split('-')[0]}`,
+                    item: item,
+                });
+            }
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
         } else if (
             lastItemReceived !== itemReceived &&

--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -75,8 +75,7 @@ class Snackbar extends Component {
         ) {
             // see if player tried to buy item without enough gold
             this.setState({
-                show: `NO GOLD FOR: ${notEnoughGold.split('-')[0]}`,
-                item: item,
+                show: `NOT ENOUGH GOLD`,
             });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
         } else if (


### PR DESCRIPTION
GitHub Issue (If applicable): #83 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Enhancement

<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

For items with long names (e.g. "Leather Armour"), the notification message on the snackbar overflows for certain messages (e.g. "Not enough gold for").

## What is the new behavior?

Notification messages have been shortened to prevent text from overflowing.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): Closes #83 
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
