### PR TITLE
Remove title for bug report closes #121

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve this project
-title: Title-Here [Low/Medium/High Priority]
+title: ''
 labels: bug
 assignees: ''
 


### PR DESCRIPTION
Other issue templates do not require a title, so the title for bug reports have been removed.

GitHub Issue (If applicable): #121 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

<!-- Please uncomment one or more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Bug reports have a default title, which includes specifying a priority.

## What is the new behavior?

Bug reports do not have a default title, meaning there is no need to specify a priority in the title.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [x] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): Closes #121 
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
