### PR TITLE
Prevent Rusty Sword from showing equip snackbar resolves #124

### DIFF
--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -131,7 +131,9 @@ class Snackbar extends Component {
                             : 'opacity .35s ease-in-out, z-index .35s step-start',
                 }}
             >
-                {showType === 'NEW ITEM' && item.type !== 'potion' ? (
+                {showType === 'NEW ITEM' &&
+                item.type !== 'potion' &&
+                item.name !== 'Rusty Sword' ? (
                     <div>
                         <span className="snackbar__equip__text">
                             {show}


### PR DESCRIPTION
GitHub Issue (If applicable): #124

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

<!-- Please uncomment one or more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Rusty Sword shows an option to equip via the snackbar on game start.

## What is the new behavior?

Rusty Sword no longer shows an option to equip via the snackbar on game start.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): #124 
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
