### PR TITLE
Race changes starting ability scores and hide increment and decrement on max and min values

### DIFF
--- a/src/components/ability/index.js
+++ b/src/components/ability/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Button from '../button';
+import { MAX_ABILITY_SCORE } from '../../config/constants';
 
 import './styles.scss';
 
@@ -11,7 +12,10 @@ const Ability = ({ name, value, minValue, increment, decrement }) => {
                 <span className="ability-score__text">{name}:</span>
                 <div
                     className="ability-score__button"
-                    style={{ visibility: value === 20 ? 'hidden' : 'visible' }}
+                    style={{
+                        visibility:
+                            value === MAX_ABILITY_SCORE ? 'hidden' : 'visible',
+                    }}
                 >
                     <Button
                         title=" "

--- a/src/components/ability/index.js
+++ b/src/components/ability/index.js
@@ -4,12 +4,15 @@ import Button from '../button';
 
 import './styles.scss';
 
-const Ability = ({ name, value, increment, decrement }) => {
+const Ability = ({ name, value, minValue, increment, decrement }) => {
     return (
         <>
             <div className="ability-score__container">
                 <span className="ability-score__text">{name}:</span>
-                <div className="ability-score__button ">
+                <div
+                    className="ability-score__button"
+                    style={{ visibility: value === 20 ? 'hidden' : 'visible' }}
+                >
                     <Button
                         title=" "
                         icon="caret-right"
@@ -19,7 +22,12 @@ const Ability = ({ name, value, increment, decrement }) => {
                     />
                 </div>
                 <span className="ability-score__score-text">{value}</span>
-                <div className="ability-score__button ">
+                <div
+                    className="ability-score__button"
+                    style={{
+                        visibility: value === minValue ? 'hidden' : 'visible',
+                    }}
+                >
                     <Button
                         title=" "
                         icon="caret-left"

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -39,6 +39,8 @@ export const MAP_TRANSITION_DELAY = 500;
 export const MAX_ABILITY_SCORE = 20;
 // The default value of an ability score
 export const STARTING_ABILITY_SCORE_VALUE = 8;
+// The default value of an ability score with race bonus
+export const RACE_BONUS_STARTING_ABILITY_SCORE_VALUE = 10;
 // The starting points a player can allocate
 export const STARTING_ABILITY_POINTS = 12;
 // The number of ability points the player gets to allocate on levelling up

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -40,7 +40,7 @@ export const MAX_ABILITY_SCORE = 20;
 // The default value of an ability score
 export const STARTING_ABILITY_SCORE_VALUE = 8;
 // The default value of an ability score with race bonus
-export const RACE_BONUS_STARTING_ABILITY_SCORE_VALUE = 10;
+export const RACE_ABILITY_BONUS = 2;
 // The starting points a player can allocate
 export const STARTING_ABILITY_POINTS = 12;
 // The number of ability points the player gets to allocate on levelling up

--- a/src/features/dialog-manager/dialogs/ability-dialog/index.js
+++ b/src/features/dialog-manager/dialogs/ability-dialog/index.js
@@ -49,6 +49,14 @@ const AbilityDialog = ({
         charisma,
         points,
     } = dialog.abilities;
+    const {
+        min_constitution,
+        min_intelligence,
+        min_strength,
+        min_dexterity,
+        min_wisdom,
+        min_charisma,
+    } = dialog.abilities_minimum;
 
     return (
         <>
@@ -63,36 +71,42 @@ const AbilityDialog = ({
                     <Ability
                         name="Strength"
                         value={strength}
+                        minValue={min_strength}
                         increment={incrementStrength}
                         decrement={decrementStrength}
                     />
                     <Ability
                         name="Constitution"
                         value={constitution}
+                        minValue={min_constitution}
                         increment={incrementConstitution}
                         decrement={decrementConstitution}
                     />
                     <Ability
                         name="Dexterity"
                         value={dexterity}
+                        minValue={min_dexterity}
                         increment={incrementDexterity}
                         decrement={decrementDexterity}
                     />
                     <Ability
                         name="Charisma"
                         value={charisma}
+                        minValue={min_charisma}
                         increment={incrementCharisma}
                         decrement={decrementCharisma}
                     />
                     <Ability
                         name="Intelligence"
                         value={intelligence}
+                        minValue={min_intelligence}
                         increment={incrementIntelligence}
                         decrement={decrementIntelligence}
                     />
                     <Ability
                         name="Wisdom"
                         value={wisdom}
+                        minValue={min_wisdom}
                         increment={incrementWisdom}
                         decrement={decrementWisdom}
                     />

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -42,29 +42,39 @@ const initialState = {
     },
     characterCreation: false,
     character: {
-        characterName: '',
+        characterName: ' ',
         characterRace: 'Human',
         characterClass: 'Fighter',
     },
+    startBuild: true,
 };
 
 const dialogManagerReducer = (state = initialState, { type, payload }) => {
     const { abilities, abilities_minimum, character } = state;
-    resetAbilityScoreValues(abilities);
-    switch (character.characterRace) {
-        case 'Human':
-            abilities.strength = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-            abilities.intelligence = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-            break;
-        case 'Elf':
-            abilities.dexterity = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-            abilities.charisma = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-            break;
-        case 'Dwarf':
-            abilities.constitution = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-            abilities.wisdom = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-            break;
-        default:
+    // if in character creation mode
+    if (state.characterCreation && character.characterName !== ' ') {
+        resetAbilityScoreValues(abilities);
+        switch (character.characterRace) {
+            case 'Human':
+                abilities.strength = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+                abilities.intelligence = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+                abilities_minimum.min_strength = 2;
+                abilities_minimum.min_intelligence = 2;
+                break;
+            case 'Elf':
+                abilities.dexterity = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+                abilities.charisma = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+                abilities_minimum.min_dexterity = 2;
+                abilities_minimum.min_charisma = 2;
+                break;
+            case 'Dwarf':
+                abilities.constitution = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+                abilities.wisdom = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+                abilities_minimum.min_constitution = 2;
+                abilities_minimum.min_wisdom = 2;
+                break;
+            default:
+        }
     }
 
     const {

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -46,7 +46,6 @@ const initialState = {
         characterRace: 'Human',
         characterClass: 'Fighter',
     },
-    startBuild: true,
 };
 
 const dialogManagerReducer = (state = initialState, { type, payload }) => {

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -4,8 +4,7 @@ import {
     MAX_ABILITY_SCORE,
 } from '../../config/constants';
 import resetAbilityScoreValues from '../../utils/reset-starting-abilities';
-import addRaceAbilityBonus from '../../utils/add-race-ability-bonus';
-import setAbilityMinimum from '../../utils/set-ability-minimum';
+import setRaceBonus from '../../utils/set-race-bonus';
 
 const initialState = {
     gameText: false,
@@ -53,31 +52,8 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
     const { abilities, abilities_minimum, character } = state;
     // if in character creation mode
     if (state.characterCreation && character.characterName !== ' ') {
-        resetAbilityScoreValues(abilities);
-        switch (character.characterRace) {
-            case 'Human':
-                addRaceAbilityBonus(abilities.strength, abilities.intelligence);
-                setAbilityMinimum(
-                    abilities_minimum.min_strength,
-                    abilities_minimum.min_intelligence
-                );
-                break;
-            case 'Elf':
-                addRaceAbilityBonus(abilities.dexterity, abilities.charisma);
-                setAbilityMinimum(
-                    abilities_minimum.min_dexterity,
-                    abilities_minimum.min_charisma
-                );
-                break;
-            case 'Dwarf':
-                addRaceAbilityBonus(abilities.constitution, abilities.wisdom);
-                addRaceAbilityBonus(
-                    abilities_minimum.min_constitution,
-                    abilities_minimum.min_wisdom
-                );
-                break;
-            default:
-        }
+        resetAbilityScoreValues(abilities, abilities_minimum);
+        setRaceBonus(character.characterRace, abilities, abilities_minimum);
     }
 
     const {

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -50,8 +50,7 @@ const initialState = {
 
 const dialogManagerReducer = (state = initialState, { type, payload }) => {
     const { abilities, abilities_minimum, character } = state;
-    // if in character creation mode
-    if (state.characterCreation && character.characterName !== '') {
+    if (state.characterCreation && character.characterName) {
         resetAbilityScoreValues(abilities, abilities_minimum);
         setRaceBonus(character.characterRace, abilities, abilities_minimum);
     }

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -50,7 +50,7 @@ const initialState = {
 
 const dialogManagerReducer = (state = initialState, { type, payload }) => {
     const { abilities, abilities_minimum, character } = state;
-    if (state.characterCreation && character.characterName) {
+    if (state.characterCreation) {
         resetAbilityScoreValues(abilities, abilities_minimum);
         setRaceBonus(character.characterRace, abilities, abilities_minimum);
     }

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -50,10 +50,6 @@ const initialState = {
 
 const dialogManagerReducer = (state = initialState, { type, payload }) => {
     const { abilities, abilities_minimum, character } = state;
-    // if (state.characterCreation) {
-    //     resetAbilityScoreValues(abilities, abilities_minimum);
-    //     setRaceBonus(character.characterRace, abilities, abilities_minimum);
-    // }
 
     const {
         constitution,

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -2,7 +2,7 @@ import {
     STARTING_ABILITY_POINTS,
     STARTING_ABILITY_SCORE_VALUE,
     MAX_ABILITY_SCORE,
-    RACE_BONUS_STARTING_ABILITY_SCORE_VALUE,
+    RACE_ABILITY_BONUS,
 } from '../../config/constants';
 import resetAbilityScoreValues from '../../utils/reset-starting-abilities';
 
@@ -55,22 +55,22 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
         resetAbilityScoreValues(abilities);
         switch (character.characterRace) {
             case 'Human':
-                abilities.strength = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-                abilities.intelligence = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-                abilities_minimum.min_strength = 2;
-                abilities_minimum.min_intelligence = 2;
+                abilities.strength += RACE_ABILITY_BONUS;
+                abilities.intelligence += RACE_ABILITY_BONUS;
+                abilities_minimum.min_strength = RACE_ABILITY_BONUS;
+                abilities_minimum.min_intelligence = RACE_ABILITY_BONUS;
                 break;
             case 'Elf':
-                abilities.dexterity = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-                abilities.charisma = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-                abilities_minimum.min_dexterity = 2;
-                abilities_minimum.min_charisma = 2;
+                abilities.dexterity += RACE_ABILITY_BONUS;
+                abilities.charisma += RACE_ABILITY_BONUS;
+                abilities_minimum.min_dexterity = RACE_ABILITY_BONUS;
+                abilities_minimum.min_charisma = RACE_ABILITY_BONUS;
                 break;
             case 'Dwarf':
-                abilities.constitution = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-                abilities.wisdom = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
-                abilities_minimum.min_constitution = 2;
-                abilities_minimum.min_wisdom = 2;
+                abilities.constitution += RACE_ABILITY_BONUS;
+                abilities.wisdom += RACE_ABILITY_BONUS;
+                abilities_minimum.min_constitution = RACE_ABILITY_BONUS;
+                abilities_minimum.min_wisdom = RACE_ABILITY_BONUS;
                 break;
             default:
         }

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -2,7 +2,9 @@ import {
     STARTING_ABILITY_POINTS,
     STARTING_ABILITY_SCORE_VALUE,
     MAX_ABILITY_SCORE,
+    RACE_BONUS_STARTING_ABILITY_SCORE_VALUE,
 } from '../../config/constants';
+import resetAbilityScoreValues from '../../utils/reset-starting-abilities';
 
 const initialState = {
     gameText: false,
@@ -48,6 +50,23 @@ const initialState = {
 
 const dialogManagerReducer = (state = initialState, { type, payload }) => {
     const { abilities, abilities_minimum, character } = state;
+    resetAbilityScoreValues(abilities);
+    switch (character.characterRace) {
+        case 'Human':
+            abilities.strength = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+            abilities.intelligence = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+            break;
+        case 'Elf':
+            abilities.dexterity = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+            abilities.charisma = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+            break;
+        case 'Dwarf':
+            abilities.constitution = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+            abilities.wisdom = RACE_BONUS_STARTING_ABILITY_SCORE_VALUE;
+            break;
+        default:
+    }
+
     const {
         constitution,
         intelligence,

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -2,9 +2,10 @@ import {
     STARTING_ABILITY_POINTS,
     STARTING_ABILITY_SCORE_VALUE,
     MAX_ABILITY_SCORE,
-    RACE_ABILITY_BONUS,
 } from '../../config/constants';
 import resetAbilityScoreValues from '../../utils/reset-starting-abilities';
+import addRaceAbilityBonus from '../../utils/add-race-ability-bonus';
+import setAbilityMinimum from '../../utils/set-ability-minimum';
 
 const initialState = {
     gameText: false,
@@ -55,22 +56,25 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
         resetAbilityScoreValues(abilities);
         switch (character.characterRace) {
             case 'Human':
-                abilities.strength += RACE_ABILITY_BONUS;
-                abilities.intelligence += RACE_ABILITY_BONUS;
-                abilities_minimum.min_strength = RACE_ABILITY_BONUS;
-                abilities_minimum.min_intelligence = RACE_ABILITY_BONUS;
+                addRaceAbilityBonus(abilities.strength, abilities.intelligence);
+                setAbilityMinimum(
+                    abilities_minimum.min_strength,
+                    abilities_minimum.min_intelligence
+                );
                 break;
             case 'Elf':
-                abilities.dexterity += RACE_ABILITY_BONUS;
-                abilities.charisma += RACE_ABILITY_BONUS;
-                abilities_minimum.min_dexterity = RACE_ABILITY_BONUS;
-                abilities_minimum.min_charisma = RACE_ABILITY_BONUS;
+                addRaceAbilityBonus(abilities.dexterity, abilities.charisma);
+                setAbilityMinimum(
+                    abilities_minimum.min_dexterity,
+                    abilities_minimum.min_charisma
+                );
                 break;
             case 'Dwarf':
-                abilities.constitution += RACE_ABILITY_BONUS;
-                abilities.wisdom += RACE_ABILITY_BONUS;
-                abilities_minimum.min_constitution = RACE_ABILITY_BONUS;
-                abilities_minimum.min_wisdom = RACE_ABILITY_BONUS;
+                addRaceAbilityBonus(abilities.constitution, abilities.wisdom);
+                addRaceAbilityBonus(
+                    abilities_minimum.min_constitution,
+                    abilities_minimum.min_wisdom
+                );
                 break;
             default:
         }

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -50,10 +50,10 @@ const initialState = {
 
 const dialogManagerReducer = (state = initialState, { type, payload }) => {
     const { abilities, abilities_minimum, character } = state;
-    if (state.characterCreation) {
-        resetAbilityScoreValues(abilities, abilities_minimum);
-        setRaceBonus(character.characterRace, abilities, abilities_minimum);
-    }
+    // if (state.characterCreation) {
+    //     resetAbilityScoreValues(abilities, abilities_minimum);
+    //     setRaceBonus(character.characterRace, abilities, abilities_minimum);
+    // }
 
     const {
         constitution,
@@ -170,6 +170,8 @@ const dialogManagerReducer = (state = initialState, { type, payload }) => {
             };
 
         case 'CREATE_CHARACTER':
+            resetAbilityScoreValues(abilities, abilities_minimum);
+            setRaceBonus(character.characterRace, abilities, abilities_minimum);
             return {
                 ...state,
                 character: {

--- a/src/features/dialog-manager/reducer.js
+++ b/src/features/dialog-manager/reducer.js
@@ -42,7 +42,7 @@ const initialState = {
     },
     characterCreation: false,
     character: {
-        characterName: ' ',
+        characterName: '',
         characterRace: 'Human',
         characterClass: 'Fighter',
     },
@@ -51,7 +51,7 @@ const initialState = {
 const dialogManagerReducer = (state = initialState, { type, payload }) => {
     const { abilities, abilities_minimum, character } = state;
     // if in character creation mode
-    if (state.characterCreation && character.characterName !== ' ') {
+    if (state.characterCreation && character.characterName !== '') {
         resetAbilityScoreValues(abilities, abilities_minimum);
         setRaceBonus(character.characterRace, abilities, abilities_minimum);
     }

--- a/src/utils/add-race-ability-bonus.js
+++ b/src/utils/add-race-ability-bonus.js
@@ -1,0 +1,5 @@
+import { RACE_ABILITY_BONUS } from '../config/constants';
+export default function addRaceAbilityBonus(ability1, ability2) {
+    ability1 += RACE_ABILITY_BONUS;
+    ability2 += RACE_ABILITY_BONUS;
+}

--- a/src/utils/add-race-ability-bonus.js
+++ b/src/utils/add-race-ability-bonus.js
@@ -1,5 +1,5 @@
 import { RACE_ABILITY_BONUS } from '../config/constants';
-export default function addRaceAbilityBonus(ability1, ability2) {
-    ability1 += RACE_ABILITY_BONUS;
-    ability2 += RACE_ABILITY_BONUS;
+export default function addRaceAbilityBonus(ability) {
+    ability += RACE_ABILITY_BONUS;
+    return ability;
 }

--- a/src/utils/reset-starting-abilities.js
+++ b/src/utils/reset-starting-abilities.js
@@ -1,0 +1,11 @@
+// Reset all ability scores to default
+import { STARTING_ABILITY_SCORE_VALUE } from '../config/constants';
+export default function resetAbilityScoreValues(abilities) {
+    abilities.strength = STARTING_ABILITY_SCORE_VALUE;
+    abilities.constitution = STARTING_ABILITY_SCORE_VALUE;
+    abilities.dexterity = STARTING_ABILITY_SCORE_VALUE;
+    abilities.charisma = STARTING_ABILITY_SCORE_VALUE;
+    abilities.intelligence = STARTING_ABILITY_SCORE_VALUE;
+    abilities.wisdom = STARTING_ABILITY_SCORE_VALUE;
+    return abilities;
+}

--- a/src/utils/reset-starting-abilities.js
+++ b/src/utils/reset-starting-abilities.js
@@ -1,11 +1,16 @@
 // Reset all ability scores to default
 import { STARTING_ABILITY_SCORE_VALUE } from '../config/constants';
-export default function resetAbilityScoreValues(abilities) {
+export default function resetAbilityScoreValues(abilities, abilities_minimum) {
     abilities.strength = STARTING_ABILITY_SCORE_VALUE;
     abilities.constitution = STARTING_ABILITY_SCORE_VALUE;
     abilities.dexterity = STARTING_ABILITY_SCORE_VALUE;
     abilities.charisma = STARTING_ABILITY_SCORE_VALUE;
     abilities.intelligence = STARTING_ABILITY_SCORE_VALUE;
     abilities.wisdom = STARTING_ABILITY_SCORE_VALUE;
-    return abilities;
+    abilities_minimum.min_strength = 0;
+    abilities_minimum.min_constituion = 0;
+    abilities_minimum.min_dexterity = 0;
+    abilities_minimum.min_charisma = 0;
+    abilities_minimum.min_intelligence = 0;
+    abilities_minimum.min_wisdom = 0;
 }

--- a/src/utils/set-ability-minimum.js
+++ b/src/utils/set-ability-minimum.js
@@ -1,0 +1,5 @@
+import { RACE_ABILITY_BONUS } from '../config/constants';
+export default function addRaceAbilityBonus(minAbility1, minAbility2) {
+    minAbility1 = RACE_ABILITY_BONUS;
+    minAbility2 = RACE_ABILITY_BONUS;
+}

--- a/src/utils/set-ability-minimum.js
+++ b/src/utils/set-ability-minimum.js
@@ -1,5 +1,5 @@
 import { RACE_ABILITY_BONUS } from '../config/constants';
-export default function addRaceAbilityBonus(minAbility1, minAbility2) {
-    minAbility1 = RACE_ABILITY_BONUS;
-    minAbility2 = RACE_ABILITY_BONUS;
+export default function addRaceAbilityBonus(minAbility) {
+    minAbility = RACE_ABILITY_BONUS;
+    return minAbility;
 }

--- a/src/utils/set-race-bonus.js
+++ b/src/utils/set-race-bonus.js
@@ -1,0 +1,45 @@
+import addRaceAbilityBonus from '../utils/add-race-ability-bonus';
+import setAbilityMinimum from '../utils/set-ability-minimum';
+export default function setRaceBonus(
+    characterRace,
+    abilities,
+    abilities_minimum
+) {
+    switch (characterRace) {
+        case 'Human':
+            abilities.strength = addRaceAbilityBonus(abilities.strength);
+            abilities.intelligence = addRaceAbilityBonus(
+                abilities.intelligence
+            );
+            abilities_minimum.min_strength = setAbilityMinimum(
+                abilities_minimum.min_strength
+            );
+            abilities_minimum.min_intelligence = setAbilityMinimum(
+                abilities_minimum.min_intelligence
+            );
+            break;
+        case 'Elf':
+            abilities.dexterity = addRaceAbilityBonus(abilities.dexterity);
+            abilities.charisma = addRaceAbilityBonus(abilities.charisma);
+            abilities_minimum.min_dexterity = setAbilityMinimum(
+                abilities_minimum.min_dexterity
+            );
+            abilities_minimum.min_charisma = setAbilityMinimum(
+                abilities_minimum.min_charisma
+            );
+            break;
+        case 'Dwarf':
+            abilities.constitution = addRaceAbilityBonus(
+                abilities.constitution
+            );
+            abilities.wisdom = addRaceAbilityBonus(abilities.wisdom);
+            abilities_minimum.min_constitution = setAbilityMinimum(
+                abilities_minimum.min_constitution
+            );
+            abilities_minimum.min_wisdom = setAbilityMinimum(
+                abilities_minimum.min_wisdom
+            );
+            break;
+        default:
+    }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #115 & #123 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
Feature
Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
1. The race a player selects during character creation has no affect on the game.
2. The arrow button to increment and decrement an ability score remains even if the button can no longer increase or decrease the ability score value.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
1. The race a player selects during character creation alters the starting ability scores and minimum possible value for their respective abilities.
2. The arrow button to increment and decrement an ability score is hidden if the ability score value is currently at either its maximum or minimum possible value.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
Closes #115 
Closes #123 