### PR TITLE
Add hotkey for equipping items closes #131

### DIFF
--- a/src/components/dialog/index.js
+++ b/src/components/dialog/index.js
@@ -4,7 +4,7 @@ import { ENTER_KEY } from '../../config/constants';
 
 import './styles.scss';
 
-const Dialog = ({ children, goBack, onKeyPress, keys }) => {
+const Dialog = ({ className, style, children, goBack, onKeyPress, keys }) => {
     useEffect(() => {
         if (onKeyPress) window.addEventListener('keydown', handleKeyPress);
         return () => {
@@ -21,7 +21,10 @@ const Dialog = ({ children, goBack, onKeyPress, keys }) => {
     }
 
     return (
-        <div className="dialog__container white-border">
+        <div
+            className={className || 'dialog__container white-border'}
+            style={style}
+        >
             {goBack && (
                 <button onClick={goBack} className="dialog__back-button">
                     <i className={`fa fa-arrow-left`} />

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -54,6 +54,7 @@ export const W_KEY = 87;
 export const S_KEY = 83;
 export const A_KEY = 65;
 export const D_KEY = 68;
+export const E_KEY = 69;
 export const U_KEY = 85;
 export const I_KEY = 73;
 export const SPACE_KEY = 32;

--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -16,6 +16,7 @@ class Snackbar extends Component {
         this.state = {
             show: '',
             item: null,
+            equip: false,
         };
 
         this.handleHideSnack = this.handleHideSnack.bind(this);
@@ -42,6 +43,8 @@ class Snackbar extends Component {
         if (lastErrorMessage !== errorMessage && errorMessage) {
             this.setState({
                 show: errorMessage.split('-')[0],
+                item: null,
+                equip: false,
             });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
         } else if (
@@ -53,6 +56,7 @@ class Snackbar extends Component {
             this.setState({
                 show: `USED ITEM: ${itemUsed.split('-')[0]}`,
                 item: item,
+                equip: false,
             });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
         } else if (
@@ -64,6 +68,7 @@ class Snackbar extends Component {
             this.setState({
                 show: `LOST ITEM: ${itemDropped.split('-')[0]}`,
                 item: item,
+                equip: false,
             });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
         } else if (
@@ -75,7 +80,10 @@ class Snackbar extends Component {
             this.setState({
                 show: `NEW ITEM: ${itemReceived.split('-')[0]}`,
                 item: item,
+                equip: false,
             });
+            if (item.type !== 'potion' && item.name !== 'Rusty Sword')
+                this.setState({ equip: true });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
         } else if (
             lastNotEnoughGold !== notEnoughGold &&
@@ -85,6 +93,8 @@ class Snackbar extends Component {
             // see if player tried to buy item without enough gold
             this.setState({
                 show: `NOT ENOUGH GOLD`,
+                item: item,
+                equip: false,
             });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
         } else if (
@@ -96,6 +106,7 @@ class Snackbar extends Component {
             this.setState({
                 show: `NO ROOM FOR: ${tooManyItems.split('-')[0]}`,
                 item: item,
+                equip: false,
             });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
         }
@@ -115,27 +126,19 @@ class Snackbar extends Component {
 
     render() {
         const { sideMenu, largeView } = this.props;
-        const { show, item } = this.state;
+        const { show, equip } = this.state;
 
         let width;
         if (sideMenu) width = 400;
         else if (largeView) width = 398;
         else width = 350;
 
-        let showType = show ? show.substring(0, show.indexOf(':')) : show;
-
         return (
             <Dialog
                 className="snackbar__container white-border"
                 keys={[E_KEY]}
                 onKeyPress={() => {
-                    if (
-                        this.state.show.includes('NEW ITEM') &&
-                        this.state.item.type !== 'potion' &&
-                        this.state.item.name !== 'Rusty Sword'
-                    ) {
-                        this.handleEquip();
-                    }
+                    if (this.state.equip) this.handleEquip();
                 }}
                 style={{
                     marginLeft: sideMenu ? -402 : 0,
@@ -151,9 +154,7 @@ class Snackbar extends Component {
                             : 'opacity .35s ease-in-out, z-index .35s step-start',
                 }}
             >
-                {showType === 'NEW ITEM' &&
-                item.type !== 'potion' &&
-                item.name !== 'Rusty Sword' ? (
+                {equip ? (
                     <div>
                         <span className="snackbar__equip__text">
                             {show}

--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -2,9 +2,10 @@ import React, { Component } from 'react';
 import ReactTimeout from 'react-timeout';
 import { connect } from 'react-redux';
 
-import { SNACK_DURATION } from '../../config/constants';
+import { SNACK_DURATION, E_KEY } from '../../config/constants';
 import equipItem from '../inventory/actions/equip-item';
 import clearNotification from './actions/clear-notification';
+import Dialog from '../../components/dialog';
 
 import './styles.scss';
 
@@ -124,8 +125,18 @@ class Snackbar extends Component {
         let showType = show ? show.substring(0, show.indexOf(':')) : show;
 
         return (
-            <div
+            <Dialog
                 className="snackbar__container white-border"
+                keys={[E_KEY]}
+                onKeyPress={() => {
+                    if (
+                        this.state.show.includes('NEW ITEM') &&
+                        this.state.item.type !== 'potion' &&
+                        this.state.item.name !== 'Rusty Sword'
+                    ) {
+                        this.handleEquip();
+                    }
+                }}
                 style={{
                     marginLeft: sideMenu ? -402 : 0,
                     top: sideMenu ? 360 : -50,
@@ -148,7 +159,7 @@ class Snackbar extends Component {
                             {show}
                             <button
                                 className="snackbar__equip__button white-border"
-                                onClick={this.handleEquip}
+                                onClick={() => this.handleEquip()}
                             >
                                 <i className="fa fa-hand-paper button__icon" />
                             </button>
@@ -157,7 +168,7 @@ class Snackbar extends Component {
                 ) : (
                     <span className="snackbar__text">{show}</span>
                 )}
-            </div>
+            </Dialog>
         );
     }
 }

--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -117,7 +117,7 @@ class Snackbar extends Component {
             this.setState({
                 show: `SOLD ITEM: ${itemSold.split('-')[0]}`,
                 item: item,
-		equip: false,
+                equip: false,
             });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
         }

--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -105,6 +105,13 @@ class Snackbar extends Component {
         this.props.clearNotification();
     }
 
+    handleEquip() {
+        this.props.equipItem(
+            this.props.inventory.items[this.props.inventory.items.length - 1]
+        );
+        this.handleHideSnack();
+    }
+
     render() {
         const { sideMenu, largeView } = this.props;
         const { show, item } = this.state;
@@ -141,15 +148,7 @@ class Snackbar extends Component {
                             {show}
                             <button
                                 className="snackbar__equip__button white-border"
-                                onClick={() => {
-                                    this.props.equipItem(
-                                        this.props.inventory.items[
-                                            this.props.inventory.items.length -
-                                                1
-                                        ]
-                                    );
-                                    this.handleHideSnack();
-                                }}
+                                onClick={this.handleEquip}
                             >
                                 <i className="fa fa-hand-paper button__icon" />
                             </button>

--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -82,10 +82,8 @@ class Snackbar extends Component {
             this.setState({
                 show: `NEW ITEM: ${itemReceived.split('-')[0]}`,
                 item: item,
-                equip: false,
+                equip: item.type !== 'potion' && item.name !== 'Rusty Sword',
             });
-            if (item.type !== 'potion' && item.name !== 'Rusty Sword')
-                this.setState({ equip: true });
             this.props.setTimeout(this.handleHideSnack, SNACK_DURATION);
         } else if (
             lastNotEnoughGold !== notEnoughGold &&


### PR DESCRIPTION
GitHub Issue (If applicable): #131 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Feature

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

The only option for equipping items from the snackbar notification is to click the button.

## What is the new behavior?

In addition to clicking the button, there is now the option to press `e` to immediately equip the item.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): Closes #131 
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
