### PR TITLE
Fix Dice Roll Parsing

### DIFF
--- a/src/__tests__/utils/calculate_dice.js
+++ b/src/__tests__/utils/calculate_dice.js
@@ -1,21 +1,27 @@
 import { calculateDamageRange } from '../../utils/dice';
 
 describe('when you roll a dice', () => {
+    test('the range should have two elements', () => {
+        const notation = '';
+        const range = calculateDamageRange(notation);
+        expect(range.length).toBe(2);
+    });
+
     test('that has the notation 1d4', () => {
         const notation = '1d4';
-
         const range = calculateDamageRange(notation);
-
-        expect(range.length).toBe(2);
         expect(range).toEqual([1, 4]);
     });
 
     test('that has the notation (2d10 + 3) * 3', () => {
         const notation = '(2d10 + 3) * 3';
-
         const range = calculateDamageRange(notation);
-
-        expect(range.length).toBe(2);
         expect(range).toEqual([15, 69]);
+    });
+
+    test('that has the notation 2d10l1 + 3', () => {
+        const notation = '2d10l1 + 3';
+        const range = calculateDamageRange(notation);
+        expect(range).toEqual([4, 13]);
     });
 });

--- a/src/__tests__/utils/calculate_dice.js
+++ b/src/__tests__/utils/calculate_dice.js
@@ -1,0 +1,21 @@
+import { calculateDamageRange } from '../../utils/dice';
+
+describe('when you roll a dice', () => {
+    test('that has the notation 1d4', () => {
+        const notation = '1d4';
+
+        const range = calculateDamageRange(notation);
+
+        expect(range.length).toBe(2);
+        expect(range).toEqual([1, 4]);
+    });
+
+    test('that has the notation (2d10 + 3) * 3', () => {
+        const notation = '( 2d10 + 3 ) * 3';
+
+        const range = calculateDamageRange(notation);
+
+        expect(range.length).toBe(2);
+        expect(range).toEqual([15, 69]);
+    });
+});

--- a/src/__tests__/utils/calculate_dice.js
+++ b/src/__tests__/utils/calculate_dice.js
@@ -11,7 +11,7 @@ describe('when you roll a dice', () => {
     });
 
     test('that has the notation (2d10 + 3) * 3', () => {
-        const notation = '( 2d10 + 3 ) * 3';
+        const notation = '(2d10 + 3) * 3';
 
         const range = calculateDamageRange(notation);
 

--- a/src/features/player/actions/attack-monster.js
+++ b/src/features/player/actions/attack-monster.js
@@ -3,7 +3,7 @@ import {
     getNewPosition,
     observeBoundaries,
 } from './move-player';
-import calculateDamage, { d20 } from '../../../utils/dice';
+import { calculateDamage, d20 } from '../../../utils/dice';
 import calculateModifier from '../../../utils/calculate-modifier';
 import getNextTile from '../../../utils/get-next-tile';
 import { SPRITE_SIZE, UNARMED_DAMAGE } from '../../../config/constants';

--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -109,6 +109,27 @@ const isNumber = str => {
     return true;
 };
 
+const lex = expression => {
+    return expression
+        .split('')
+        .reduce((output, token) => {
+            if (token in ops) {
+                output.push(token);
+            } else if (token == '(' || token == ')') {
+                output.push(token);
+            } else if (token.trim().length > 0) {
+                if (output.length > 0 && isNumber(output[output.length - 1])) {
+                    output.push(output.pop() + token);
+                } else {
+                    output.push(token);
+                }
+            }
+
+            return output;
+        }, [])
+        .join(' ');
+};
+
 // Djikstra's shunting yard algorithm to convert infix notation to postfix notation
 const yard = infix => {
     let stack = [];
@@ -182,15 +203,19 @@ const rpn = (postfix, die) => {
         : evaluated;
 };
 
+const parse = (notation, dice) => {
+    const lexed = lex(notation);
+    return rpn(yard(lexed), dice);
+};
+
 export const calculateDamageRange = notation => {
-    const pf = yard(notation);
-    const min = rpn(pf, biased('min'));
-    const max = rpn(pf, biased('max'));
+    const min = parse(notation, biased('min'));
+    const max = parse(notation, biased('max'));
     return [min, max];
 };
 
 // Calculates damage to deal based on Dice Notation (https://en.wikipedia.org/wiki/Dice_notation)
 export default function calculateDamage(notation) {
-    const damage = rpn(yard(notation), unbiased());
+    const damage = parse(notation, unbiased());
     return damage;
 }

--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -87,28 +87,73 @@ const ops = {
     },
 };
 
+const peek = a => a[a.length - 1];
+
+const reorder = (stack, token, out) => {
+    while (
+        peek(stack) in ops &&
+        ops[token].precedence <= ops[peek(stack)].precedence
+    ) {
+        out.push(stack.pop());
+    }
+};
+
+const isNumber = str => {
+    for (let i = 0; i < str.length; i++) {
+        const ch = str.charAt(i);
+        if (ch < '0' || ch > '9') {
+            return false;
+        }
+    }
+
+    return true;
+};
+
 // Djikstra's shunting yard algorithm to convert infix notation to postfix notation
-let yard = infix => {
-    let peek = a => a[a.length - 1];
+const yard = infix => {
     let stack = [];
 
     return infix
-        .split('')
+        .split(' ')
         .reduce((output, token) => {
             if (token in ops) {
-                while (
-                    peek(stack) in ops &&
-                    ops[token].precedence <= ops[peek(stack)].precedence
-                )
-                    output.push(stack.pop());
+                reorder(stack, token, output);
                 stack.push(token);
-            } else if (parseInt(token)) {
-                output.push(token);
             } else if (token === '(') {
                 stack.push(token);
             } else if (token === ')') {
                 while (peek(stack) !== '(') output.push(stack.pop());
                 stack.pop();
+            } else if (isNumber(token)) {
+                // It's just a number, so put it to the output
+                output.push(token);
+            } else if (token.includes('d')) {
+                // We have a dice throw
+                let tokens = token.split('d');
+
+                // This is the multiplier, so push it to the output
+                output.push(tokens[0]);
+                reorder(stack, 'd', output);
+                stack.push('d');
+
+                const selector = tokens[1].includes('l')
+                    ? 'l' // Remove the lowest n throws
+                    : tokens[1].includes('h')
+                    ? 'h' // Take the highest n throws
+                    : null;
+
+                if (selector !== null) {
+                    let selected = tokens[1].split(selector);
+                    // Push the sides of the dice regardless
+                    output.push(selected[0]);
+
+                    reorder(stack, selector, output);
+                    stack.push(selector);
+                    output.push(selected[1]);
+                } else {
+                    // No selector, just the sides left
+                    output.push(tokens[1]);
+                }
             }
 
             return output;
@@ -118,19 +163,23 @@ let yard = infix => {
 };
 
 const rpn = (postfix, die) => {
-    let stack = [];
+    const evaluated = postfix
+        .split(' ')
+        .reduce((stack, token) => {
+            if (token in ops) {
+                let right = stack.pop();
+                let left = stack.pop();
+                stack.push(ops[token].op(left, right, die));
+            } else {
+                stack.push(token);
+            }
+            return stack;
+        }, [])
+        .pop();
 
-    postfix.split(' ').forEach(token => {
-        if (token in ops) {
-            let right = stack.pop();
-            let left = stack.pop();
-            stack.push(ops[token].op(left, right, die));
-        } else {
-            stack.push(token);
-        }
-    });
-
-    return stack[0];
+    return Array.isArray(evaluated) // We can either get a value here, or an array (indicating the last item is a dice roll)
+        ? evaluated.reduce((sum, value) => sum + value, 0)
+        : evaluated;
 };
 
 export const calculateDamageRange = notation => {

--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -1,7 +1,5 @@
 // Create an 'unbiased' roll
-const unbiased = () => {
-    return sides => Math.floor(Math.random() * sides) + 1;
-};
+const unbiased = sides => Math.floor(Math.random() * sides) + 1;
 
 // Create a 'biased' dice roll, either to the maximum or the minimum value, if not specified, return an unbiased roll
 const biased = to => {
@@ -208,10 +206,7 @@ const rpn = (postfix, die) => {
         : evaluated;
 };
 
-const parse = (notation, dice) => {
-    const lexed = lex(notation);
-    return rpn(yard(lexed), dice);
-};
+const parse = (notation, dice) => rpn(yard(lex(notation)), dice);
 
 export const calculateDamageRange = notation => {
     const min = parse(notation, biased('min'));
@@ -220,9 +215,6 @@ export const calculateDamageRange = notation => {
 };
 
 // Calculates damage to deal based on Dice Notation (https://en.wikipedia.org/wiki/Dice_notation)
-export default function calculateDamage(notation) {
-    const damage = parse(notation, unbiased());
-    return damage;
-}
+export const calculateDamage = notation => parse(notation, unbiased());
 
 export const d20 = () => Math.floor(Math.random() * 20) + 1;


### PR DESCRIPTION
GitHub Issue (If applicable): #143 

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Documentation content changes

## What is the current behavior?
The dice rolls are not being parsed correctly, leaving behind extra characters if they aren't behind spaces (so '(2d10 + 3) * 3' gives a different range to '( 2d10 + 3 ) * 3).


## What is the new behavior?
I've added some test cases, which really should be improved upon, that check this behaviour. I added a lexer to help combat these issues in future, so that we can more easily handle it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [x] Added new tests to the test suite for the feature
- [x] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): closes #143 
