### PR TITLE
Remove 'attack' References from Dialogs and Items

### DIFF
--- a/src/data/items/rings/amethyst-ring/index.js
+++ b/src/data/items/rings/amethyst-ring/index.js
@@ -4,7 +4,6 @@ const AmethystRing = {
     name: 'Amethyst Ring',
     type: 'ring',
     effect: {
-        damage: 8,
         defence: 3,
     },
     image: AmethystRingImg,

--- a/src/data/items/rings/diamond-ring/index.js
+++ b/src/data/items/rings/diamond-ring/index.js
@@ -4,7 +4,6 @@ const DiamondRing = {
     name: 'Diamond Ring',
     type: 'ring',
     effect: {
-        damage: 3,
         defence: 10,
     },
     image: DiamondRingImg,

--- a/src/data/items/rings/old-ring/index.js
+++ b/src/data/items/rings/old-ring/index.js
@@ -4,7 +4,6 @@ const OldRing = {
     name: 'Old Ring',
     type: 'ring',
     effect: {
-        damage: 1,
         defence: 1,
         hp: 4,
     },

--- a/src/data/monsters/dragon/index.js
+++ b/src/data/monsters/dragon/index.js
@@ -3,7 +3,7 @@ import DragonSprite from './dragon.png';
 const Dragon = {
     hp: 60,
     maxHp: 60,
-    attack: 15,
+    attackValue: 15,
     defence: 8,
     dice: '2d8 + 1',
     exp: 400,

--- a/src/data/monsters/goblin/index.js
+++ b/src/data/monsters/goblin/index.js
@@ -3,7 +3,7 @@ import GoblinSprite from './goblin.png';
 const Goblin = {
     hp: 12,
     maxHp: 12,
-    attack: 4,
+    attackValue: 4,
     defence: 3,
     dice: '1d6',
     exp: 25,

--- a/src/data/monsters/imp/index.js
+++ b/src/data/monsters/imp/index.js
@@ -3,7 +3,7 @@ import ImpSprite from './imp.png';
 const Imp = {
     hp: 40,
     maxHp: 40,
-    attack: 10,
+    attackValue: 10,
     defence: 2,
     dice: '2d4 + 2',
     exp: 150,

--- a/src/data/monsters/lich/index.js
+++ b/src/data/monsters/lich/index.js
@@ -3,7 +3,7 @@ import LichSprite from './lich.png';
 const Lich = {
     hp: 100,
     maxHp: 100,
-    attack: 22,
+    attackValue: 22,
     defence: 12,
     dice: '2d20',
     exp: 1000,

--- a/src/data/monsters/rat/index.js
+++ b/src/data/monsters/rat/index.js
@@ -3,7 +3,7 @@ import RatSprite from './rat.png';
 const Rat = {
     hp: 8,
     maxHp: 8,
-    attack: 2,
+    attackValue: 2,
     defence: 0,
     dice: '1d4',
     exp: 8,

--- a/src/data/monsters/stone-golem/index.js
+++ b/src/data/monsters/stone-golem/index.js
@@ -3,7 +3,7 @@ import GolemSprite from './stone-golem.png';
 const StoneGolem = {
     hp: 30,
     maxHp: 30,
-    attack: 8,
+    attackValue: 8,
     defence: 5,
     dice: '1d8 + 2',
     exp: 60,

--- a/src/features/dialog-manager/dialogs/level-up/index.js
+++ b/src/features/dialog-manager/dialogs/level-up/index.js
@@ -33,11 +33,6 @@ const LevelUp = ({ stats, closeLevelUpDialog, abilityScoreDialog }) => {
                         Hp
                     </div>
                 )}
-
-                <div className="level-up__value--spacing">
-                    Gained<span className="level-up__dmg">{` +${dmg} `}</span>
-                    Attack
-                </div>
             </div>
 
             <div className="flex-column level-up__buttons">

--- a/src/features/journal/reducer.js
+++ b/src/features/journal/reducer.js
@@ -14,7 +14,7 @@ const journalReducer = (state = initialState, { type, payload }) => {
                 'The ' +
                     payload.type +
                     ' attacked you with an attack value of ' +
-                    payload.attack_value +
+                    payload.attackValue +
                     ' against your defense value of ' +
                     payload.check
             );

--- a/src/features/monsters/actions/attack-player.js
+++ b/src/features/monsters/actions/attack-player.js
@@ -12,7 +12,7 @@ export default function attackPlayer(attackValue, dice, type) {
         dispatch({
             type: 'MONSTER_ABILITY_CHECK',
             payload: {
-                attack_value: attackValue,
+                attackValue: attackValue,
                 check: Math.max(stats.defence, 0),
                 type: type,
             },

--- a/src/features/monsters/actions/take-monsters-turn.js
+++ b/src/features/monsters/actions/take-monsters-turn.js
@@ -15,9 +15,9 @@ export default function takeMonstersTurn() {
         // find each monster
         Object.keys(components[currentMap]).forEach(monsterId => {
             // get monster id and position
-            const { id, position, attack, dice, type } = components[currentMap][
-                monsterId
-            ];
+            const { id, position, attackValue, dice, type } = components[
+                currentMap
+            ][monsterId];
             // find the relative position
             const monsterPos = position.map(value => value / SPRITE_SIZE);
 
@@ -39,7 +39,7 @@ export default function takeMonstersTurn() {
                 const { player } = getState();
                 // check if player is in range
                 if (playerInRange(player.position, monsterPos)) {
-                    dispatch(attackPlayer(attack, dice, type));
+                    dispatch(attackPlayer(attackValue, dice, type));
                 } else {
                     // no player in range, time to move!
                     // get the monsters actual position in pixels

--- a/src/features/player/actions/attack-monster.js
+++ b/src/features/player/actions/attack-monster.js
@@ -27,20 +27,20 @@ export default function attackMonster() {
                 const monsterPos = currMonster.position;
 
                 const modifier = calculateModifier(stats.abilities.strength);
-                const attack_value = d20() + modifier;
+                const attackValue = d20() + modifier;
 
                 dispatch({
                     type: 'ABILITY_CHECK',
                     payload: {
                         notation: 'd20 + ' + modifier,
-                        roll: attack_value,
+                        roll: attackValue,
                         ability: 'strength',
                         check: currMonster.defence,
                     },
                 });
 
                 const damage =
-                    attack_value >= currMonster.defence
+                    attackValue >= currMonster.defence
                         ? calculateDamage(
                               weapon ? weapon.damage : UNARMED_DAMAGE
                           )

--- a/src/features/stats/reducer.js
+++ b/src/features/stats/reducer.js
@@ -24,14 +24,13 @@ const initialState = {
     maxHp: 0,
     mana: 0,
     maxMana: 0,
-    damage: 3,
     defence: 0,
     level: 1,
     exp: 0,
     expToLevel: 20,
     gold: 0,
     equippedItems: {},
-    levelUp: { level: 0, hp: 0, dmg: 0 },
+    levelUp: { level: 0, hp: 0 },
 };
 
 const statsReducer = (state = initialState, { type, payload }) => {
@@ -90,7 +89,6 @@ const statsReducer = (state = initialState, { type, payload }) => {
             // check the type
             switch (payload.type) {
                 case 'weapon':
-                    newState.damage -= payload.damage;
                     delete newState.equippedItems.weapon;
                     break;
 
@@ -127,10 +125,6 @@ const statsReducer = (state = initialState, { type, payload }) => {
                                 newState.defence -= payload.effect[effectName];
                                 break;
 
-                            case 'damage':
-                                newState.damage -= payload.effect[effectName];
-                                break;
-
                             case 'hp':
                                 newState.hp -= payload.effect[effectName];
                                 if (newState.hp < 1) newState.hp = 1;
@@ -155,12 +149,6 @@ const statsReducer = (state = initialState, { type, payload }) => {
             // see what type of item it is
             switch (item.type) {
                 case 'weapon':
-                    // if there's already a weapon
-                    if (newState.equippedItems.weapon) {
-                        // subtract it's benefits
-                        newState.damage -= newState.equippedItems.weapon.damage;
-                    }
-                    newState.damage += item.damage;
                     newState.equippedItems.weapon = item;
                     break;
 
@@ -266,11 +254,6 @@ const statsReducer = (state = initialState, { type, payload }) => {
                                         equippedRing.effect[effectName];
                                     break;
 
-                                case 'damage':
-                                    newState.damage -=
-                                        equippedRing.effect[effectName];
-                                    break;
-
                                 case 'hp':
                                     newState.hp -=
                                         equippedRing.effect[effectName];
@@ -289,10 +272,6 @@ const statsReducer = (state = initialState, { type, payload }) => {
                         switch (effectName) {
                             case 'defence':
                                 newState.defence += item.effect[effectName];
-                                break;
-
-                            case 'damage':
-                                newState.damage += item.effect[effectName];
                                 break;
 
                             case 'hp':
@@ -357,16 +336,6 @@ const statsReducer = (state = initialState, { type, payload }) => {
                 newState.hp += newState.levelUp.hp;
                 newState.maxHp += newState.levelUp.hp;
                 newState.abilityModifierHp = newAbilityModifierHp;
-
-                // get more damage (+1)
-                let moreDmg = 1;
-                // 25% chance to get +2 damage on lv
-                const chance = Math.floor(Math.random() * 100) + 1;
-                if (chance <= 25) {
-                    moreDmg += 1;
-                }
-                newState.damage += moreDmg;
-                newState.levelUp.dmg = moreDmg;
             } else {
                 // they aren't leveling up
                 newState.exp += payload;


### PR DESCRIPTION
GitHub Issue (If applicable): #163 

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Some items and dialogs reference an 'attack' value, which was removed in earlier PR's.

## What is the new behavior?
This 'attack' value is no longer referenced in any dialogs, or items.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 

Internal Issue (If applicable): closes #163 
