### PR TITLE
Add critical hits

### DIFF
--- a/src/features/journal/reducer.js
+++ b/src/features/journal/reducer.js
@@ -41,6 +41,25 @@ const journalReducer = (state = initialState, { type, payload }) => {
             return newState;
         }
 
+        case 'CRITICAL_HIT': {
+            const { ability, roll } = payload;
+
+            newState = cloneDeep(state);
+            newState.entries.push({
+                key: uuidv4(),
+                entry: (
+                    <p key={uuidv4()}>
+                        You performed {aOrAn(ability)}{' '}
+                        {colourise(ability, 'ability')} check and rolled a{' '}
+                        {colourise(roll, 'score')},
+                        {colourise(' critical hit!', 'damage-to-monster')}
+                    </p>
+                ),
+            });
+
+            return newState;
+        }
+
         case 'ABILITY_CHECK': {
             const { ability, entity, roll, check, against } = payload;
 

--- a/src/features/player/actions/attack-monster.js
+++ b/src/features/player/actions/attack-monster.js
@@ -142,25 +142,12 @@ export default function attackMonster() {
                     });
                 }
 
-                let damage =
-                    attackValue >= currMonster.defence
-                        ? calculateDamage(weapon.damage)
+                const damage =
+                    roll === 20
+                        ? calculateDamage(weapon.damage, true)
+                        : attackValue >= currMonster.defence
+                        ? calculateDamage(weapon.damage, false)
                         : 0;
-
-                //critical hit
-                if (roll === 20) {
-                    const weaponFront = weapon.damage.slice(0);
-                    const weaponBack = weapon.damage.slice(
-                        1,
-                        weapon.damage.length
-                    );
-                    const diceValue = (parseInt(weaponFront) * 2).toString();
-                    const weaponDamage = diceValue.concat(weaponBack);
-                    damage =
-                        attackValue >= currMonster.defence
-                            ? calculateDamage(weaponDamage)
-                            : 0;
-                }
 
                 if (damage > 0) {
                     // Only show the attack animation if they hit the monster

--- a/src/features/player/actions/cast-spell.js
+++ b/src/features/player/actions/cast-spell.js
@@ -59,28 +59,41 @@ export default function castSpell() {
                     stats.abilities.intelligence
                 );
 
-                const attackValue = d20() + modifier;
+                const roll = d20();
+                const attackValue = roll + modifier;
 
                 dispatch({
                     type: 'CAST_SPELL',
                     payload: { position: spellPosition, projectile: spell },
                 });
 
-                dispatch({
-                    type: 'ABILITY_CHECK',
-                    payload: {
-                        notation: 'd20 + ' + modifier,
-                        roll: attackValue,
-                        ability: 'intelligence',
-                        check: currMonster.defence,
-                        entity: currMonster.type,
-                        against: 'defence',
-                    },
-                });
+                if (roll === 20) {
+                    dispatch({
+                        type: 'CRITICAL_HIT',
+                        payload: {
+                            notation: 'd20 + ' + modifier,
+                            roll: roll,
+                        },
+                    });
+                } else {
+                    dispatch({
+                        type: 'ABILITY_CHECK',
+                        payload: {
+                            notation: 'd20 + ' + modifier,
+                            roll: attackValue,
+                            ability: 'intelligence',
+                            check: currMonster.defence,
+                            entity: currMonster.type,
+                            against: 'defence',
+                        },
+                    });
+                }
 
                 const damage =
-                    attackValue >= currMonster.defence
-                        ? calculateDamage(spell.damage)
+                    roll === 20
+                        ? calculateDamage(spell.damage, true)
+                        : attackValue >= currMonster.defence
+                        ? calculateDamage(spell.damage, false)
                         : 0;
 
                 // deal damage to monster

--- a/src/features/player/actions/cast-spell.js
+++ b/src/features/player/actions/cast-spell.js
@@ -73,6 +73,7 @@ export default function castSpell() {
                         payload: {
                             notation: 'd20 + ' + modifier,
                             roll: roll,
+                            ability: 'intelligence',
                         },
                     });
                 } else {

--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -14,7 +14,7 @@ const biased = to => {
 const ops = {
     '+': {
         precedence: 1,
-        op: (left, right, _) => {
+        op: (left, right) => {
             if (Array.isArray(left)) {
                 left = left.reduce((sum, value) => sum + value);
             }
@@ -26,7 +26,7 @@ const ops = {
     },
     '-': {
         precedence: 1,
-        op: (left, right, _) => {
+        op: (left, right) => {
             if (Array.isArray(left)) {
                 left = left.reduce((sum, value) => sum + value);
             }
@@ -38,7 +38,7 @@ const ops = {
     },
     '*': {
         precedence: 2,
-        op: (left, right, _) => {
+        op: (left, right) => {
             if (Array.isArray(left)) {
                 left = left.reduce((sum, value) => sum + value);
             }
@@ -50,7 +50,7 @@ const ops = {
     },
     '/': {
         precedence: 2,
-        op: (left, right, _) => {
+        op: (left, right) => {
             if (Array.isArray(left)) {
                 left = left.reduce((sum, value) => sum + value);
             }
@@ -62,24 +62,24 @@ const ops = {
     },
     l: {
         precedence: 3,
-        op: (left, right, _) => {
+        op: (left, right) => {
             // Remove the lowest `right` number of rolls
             return left.sort().splice(right);
         },
     },
     h: {
         precedence: 3,
-        op: (left, right, _) => {
+        op: (left, right) => {
             // Select the highest `right` number of rolls
             return left.sort((l, r) => r - l).splice(right);
         },
     },
     d: {
         precedence: 4,
-        op: (left, right, die) => {
-            let mul = parseInt(left);
-            let sides = parseInt(right);
-            let rolls = [];
+        op: (left, right, criticalHit, die) => {
+            const mul = parseInt(left) * criticalHit ? 2 : 1;
+            const sides = parseInt(right);
+            const rolls = [];
             for (let i = 0; i < mul; i++) {
                 rolls.push(die(sides));
             }
@@ -185,14 +185,14 @@ const yard = infix => {
 };
 
 // Evaluate a reverse polish notation (postfix) expression
-const rpn = (postfix, die) => {
+const rpn = (postfix, criticalHit, die) => {
     const evaluated = postfix
         .split(' ')
         .reduce((stack, token) => {
             if (token in ops) {
                 let right = stack.pop();
                 let left = stack.pop();
-                stack.push(ops[token].op(left, right, die));
+                stack.push(ops[token].op(left, right, criticalHit, die));
             } else {
                 stack.push(token);
             }
@@ -206,8 +206,8 @@ const rpn = (postfix, die) => {
         : evaluated;
 };
 
-const parse = (notation, dice) => rpn(yard(lex(notation)), dice);
-const crit = sides => 2 * unbiased(sides);
+const parse = (notation, criticalHit, dice) =>
+    rpn(yard(lex(notation)), criticalHit, dice);
 
 export const calculateDamageRange = notation => {
     const min = parse(notation, biased('min'));
@@ -217,6 +217,6 @@ export const calculateDamageRange = notation => {
 
 // Calculates damage to deal based on Dice Notation (https://en.wikipedia.org/wiki/Dice_notation)
 export const calculateDamage = (notation, criticalHit) =>
-    parse(notation, criticalHit ? crit : unbiased);
+    parse(notation, criticalHit, unbiased);
 
 export const d20 = () => Math.floor(Math.random() * 20) + 1;

--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -207,6 +207,7 @@ const rpn = (postfix, die) => {
 };
 
 const parse = (notation, dice) => rpn(yard(lex(notation)), dice);
+const crit = sides => 2 * unbiased(sides);
 
 export const calculateDamageRange = notation => {
     const min = parse(notation, biased('min'));
@@ -215,6 +216,8 @@ export const calculateDamageRange = notation => {
 };
 
 // Calculates damage to deal based on Dice Notation (https://en.wikipedia.org/wiki/Dice_notation)
-export const calculateDamage = notation => parse(notation, unbiased);
+//export const calculateDamage = notation => parse(notation, unbiased);
+export const calculateDamage = (notation, criticalHit) =>
+    parse(notation, criticalHit ? crit : unbiased);
 
 export const d20 = () => Math.floor(Math.random() * 20) + 1;

--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -216,7 +216,6 @@ export const calculateDamageRange = notation => {
 };
 
 // Calculates damage to deal based on Dice Notation (https://en.wikipedia.org/wiki/Dice_notation)
-//export const calculateDamage = notation => parse(notation, unbiased);
 export const calculateDamage = (notation, criticalHit) =>
     parse(notation, criticalHit ? crit : unbiased);
 


### PR DESCRIPTION
GitHub Issue (If applicable): #213 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The game does not currently support critical hits.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
When a player rolls a natural 20 on the dice before modifier bonus, the attack will always hit and do double damage.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
Closes #213 