### PR TITLE
Change bow to crossbow in tutorial item page fixes #249

### DIFF
--- a/src/features/dialog-manager/dialogs/tutorial-dialog/pages/item-tutorial.js
+++ b/src/features/dialog-manager/dialogs/tutorial-dialog/pages/item-tutorial.js
@@ -6,7 +6,7 @@ import Shop from './assets/shop.png';
 import Broadsword from '../../../../../data/items/weapons/swords/broad-sword/broad-sword.png';
 import HealthPotion from '../../../../../data/items/potions/hp-potion/hp-potion.png';
 import SteelArmour from '../../../../../data/items/clothes/armor/steel-armor/steel-armor.png';
-import Bow from '../../../../../data/items/weapons/ranged/bow/bow.png';
+import Crossbow from '../../../../../data/items/weapons/ranged/crossbow/crossbow.png';
 import ManaPotion from '../../../../../data/items/potions/mp-potion/mp-potion.png';
 import AmethystRing from '../../../../../data/items/rings/amethyst-ring/amethyst-ring.png';
 
@@ -33,7 +33,7 @@ const ItemTutorial = () => {
                     <img src={Broadsword} alt="broadsword" width={50} />
                     <img src={HealthPotion} alt="health potion" width={50} />
                     <img src={SteelArmour} alt="steel armour" width={50} />
-                    <img src={Bow} alt="bow" width={50} />
+                    <img src={Crossbow} alt="crossbow" width={50} />
                     <img src={ManaPotion} alt="mana potion" width={50} />
                     <img src={AmethystRing} alt="amethyst ring" width={50} />
                 </div>


### PR DESCRIPTION
GitHub Issue (If applicable): #249 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The item page attempts to use a deprecated bow sprite, thus crashing the game.

## What is the new behavior?

Instead of the bow, the crossbow is used and displayed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [x] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): Fixes #249 
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
