### PR TITLE
Add tooltips to character creation screen closes #285

### DIFF
--- a/src/features/dialog-manager/dialogs/character-creation/index.js
+++ b/src/features/dialog-manager/dialogs/character-creation/index.js
@@ -79,7 +79,14 @@ const CharacterCreation = ({
                     onChange={event => setCharacterName(event.target.value)}
                 />
 
-                <span style={{ paddingTop: 12 }}>{`Your Race`}</span>
+                <span style={{ paddingTop: 12 }}>
+                    {`Your Race`}
+                    <i className="fa fa-question-circle character-creation__tooltip">
+                        <span className="character-creation__tooltip-text">
+                            {'Affects starting stats'}
+                        </span>
+                    </i>
+                </span>
                 <div className="container space-around">
                     <SelectButtonGroup
                         values={['Human', 'Elf', 'Dwarf']}
@@ -90,7 +97,14 @@ const CharacterCreation = ({
                     />
                 </div>
 
-                <span style={{ paddingTop: 12 }}>{`Your Class`}</span>
+                <span style={{ paddingTop: 12 }}>
+                    {`Your Class`}
+                    <i className="fa fa-question-circle character-creation__tooltip">
+                        <span className="character-creation__tooltip-text">
+                            {'Affects starting items'}
+                        </span>
+                    </i>
+                </span>
                 <div className="container space-around">
                     <SelectButtonGroup
                         values={['Fighter', 'Wizard', 'Ranger']}

--- a/src/features/dialog-manager/dialogs/character-creation/styles.scss
+++ b/src/features/dialog-manager/dialogs/character-creation/styles.scss
@@ -52,3 +52,35 @@
 .container.space-between {
     justify-content: space-between;
 }
+
+.character-creation__tooltip {
+    justify-content: center;
+    margin-left: 10px;
+    font-size: 16px;
+
+    .character-creation__tooltip-text {
+        font-family: Montserrat;
+        font-size: 14px;
+        text-transform: none;
+        font-weight: 400;
+        line-height: 1;
+        visibility: hidden;
+
+        padding: 5px;
+        margin-top: -5px;
+
+        background-color: var(--dark-gray);
+        border: 0.5px var(--gray) solid;
+
+        color: var(--gray);
+
+        /* Position the tooltip */
+        position: absolute;
+        left: 60px;
+        z-index: 1;
+    }
+}
+
+.character-creation__tooltip:hover .character-creation__tooltip-text {
+    visibility: visible;
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #285 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Enhancement

## What is the current behavior?

No tooltips on character creation screen means new players have some confusion around the impact of their choice of race/class.

## What is the new behavior?

Tooltips are added to character creation screen.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): Closes #285
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
