### PR TITLE
Fix Broken Stats Bar

### DIFF
--- a/src/features/dialog-manager/actions/confirm-ability-score-dialog.js
+++ b/src/features/dialog-manager/actions/confirm-ability-score-dialog.js
@@ -38,6 +38,7 @@ export default function confirmAbilityScoreDialog() {
             });
         } else {
             dispatch(loadStartingItems());
+            dispatch({ type: 'PAUSE', payload: { gameRunning: true } });
             if (gameType === 'endless') {
                 dispatch(showEndlessMessage());
             } else {


### PR DESCRIPTION
This fix was checked with Andrew before hand (see attached Email Photo
in the relevant PR).

This fix was required to make some of the important functionality work
in the game that was accidentally broken in the last PR made
1696d31dbc70ead899d96df777e99e816135e733.

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
No Stats Bar was displaying when starting the game.

## What is the new behavior?
It now does.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 

## Other information
This was allowed by Andrew after discussing the consequences of this not being done. 
![andrew email](https://user-images.githubusercontent.com/45865186/83719685-b70d7980-a68b-11ea-8442-403968822006.PNG)
