### PR TITLE
Change 'mp' to 'mana' in ViewItem for MpDiff

### DIFF
--- a/src/components/view-item/index.js
+++ b/src/components/view-item/index.js
@@ -324,7 +324,7 @@ const ViewItem = ({
     }
 
     const HpDiff = stats.maxHp - stats.hp;
-    const MpDiff = stats.maxMp - stats.mp;
+    const MpDiff = stats.maxMana - stats.mana;
 
     return (
         <MicroDialog


### PR DESCRIPTION
Reference to non-existent attributes 'maxMp' and 'mp' causes mana potions to restore null values. This PR fixes those typos by correcting them to 'maxMana' and 'mana' respectively.

GitHub Issue (If applicable): #342 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Attempting to use mana potions to restore mana results in a `NaN` value for mana.

## What is the new behavior?

Mana potions work as expected.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [x] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->

## Other information

N/A

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): Fixes #342 
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
